### PR TITLE
Fix import json for django 2

### DIFF
--- a/nocaptcha_recaptcha/client.py
+++ b/nocaptcha_recaptcha/client.py
@@ -2,10 +2,10 @@ import logging
 
 import django
 
-if django.VERSION[1] >= 5:
-    import json
-else:
+try:
     from django.utils import simplejson as json
+except ImportError:
+    import json
 
 from django.conf import settings
 from django.template.loader import render_to_string


### PR DESCRIPTION
I changed the way I tried import, as it was before it only tested the second version number.
When Django switched to version 2, the second number turned 0, which is why he thought Django was below version 1.5.